### PR TITLE
Remove .rivet from auto-generated .gitignore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Global flags (`--api-endpoint`, `--token`, and `--disable-telemetry`) can now be used in subcommands (e.g. `rivet init --token foobar` instead of `rivet --token foobar init`)
 - Moved project metadata to global configuration file
+- Removed `.rivet` from auto-generated `.gitignore`
 
 ### Fixed
 

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -202,17 +202,17 @@ impl Opts {
 			if self.recommend
 				|| self.update_gitignore
 				|| term::Prompt::new("Add .env to .gitignore?")
-					.docs(".rivet/ holds secrets and local configuration files that should not be version controlled")
-					.docs_url("https://rivet.gg/docs/general/concepts/dot-rivet-directory")
+					.docs(".env holds the develpoment token that should not be version controlled")
 					.default_value("yes")
-					.bool(term).await?
+					.bool(term)
+					.await?
 			{
 				let mut file = fs::OpenOptions::new()
 					.write(true)
 					.append(true)
 					.open(".gitignore")
 					.await?;
-				file.write_all(b"\n### Rivet ###\n.env\n").await?;
+				file.write_all(b"\n.env\n").await?;
 
 				ensure!(
 					git::check_ignore(Path::new(".env")).await?,

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -198,10 +198,10 @@ impl Opts {
 	}
 
 	async fn update_gitignore(&self, term: &Term) -> Result<()> {
-		if !git::check_ignore(Path::new(".rivet/")).await? {
+		if !git::check_ignore(Path::new(".env")).await? {
 			if self.recommend
 				|| self.update_gitignore
-				|| term::Prompt::new("Add .rivet/ to .gitignore?")
+				|| term::Prompt::new("Add .env to .gitignore?")
 					.docs(".rivet/ holds secrets and local configuration files that should not be version controlled")
 					.docs_url("https://rivet.gg/docs/general/concepts/dot-rivet-directory")
 					.default_value("yes")
@@ -212,19 +212,19 @@ impl Opts {
 					.append(true)
 					.open(".gitignore")
 					.await?;
-				file.write_all(b"\n### Rivet ###\n.rivet/\n.env\n").await?;
+				file.write_all(b"\n### Rivet ###\n.env\n").await?;
 
 				ensure!(
-					git::check_ignore(Path::new(".rivet/")).await?,
-					"updated gitignore does not ignore Rivet files"
+					git::check_ignore(Path::new(".env")).await?,
+					"updated gitignore does not ignore .env"
 				);
 
-				term::status::success("Finished", "Git will now ignore the .rivet/ folder");
+				term::status::success("Finished", "Git will now ignore the .env file");
 			}
 		} else {
 			term::status::success(
 				".gitignore already configured",
-				"The .rivet/ folder is already ignored by Git",
+				"The .env file is already ignored by Git",
 			);
 		}
 


### PR DESCRIPTION
No longer required with global config

Fixes CLI-18
