### PR TITLE
Remove redundant prompt for init engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Removed engine prompt if Rivet config already exists
 - **[BREAKING]** No longer automatically creates/updates `.env` file in favor of using `rivet token create development`
 - Global flags (`--api-endpoint`, `--token`, and `--disable-telemetry`) can now be used in subcommands (e.g. `rivet init --token foobar` instead of `rivet --token foobar init`)
 - Moved project metadata to global configuration file

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -123,8 +123,24 @@ impl Opts {
 			.init_ctx_and_token(term, token.as_ref().map(|x| x.as_str()), api_endpoint)
 			.await?;
 
+        // Attempt to read the existing config
+        let partial_config = 
+			commands::version::read_config_partial(Vec::new(), None).await.ok();
+
 		// Select the engine to use
-		let init_engine = if self.unity {
+		let init_engine = if let Some(engine) = partial_config.as_ref().and_then(|x| x.engine.as_ref()) {
+            if engine.unity.is_some() {
+                InitEngine::Unity
+            } else if engine.unreal.is_some() {
+                InitEngine::Unreal
+            } else if engine.godot.is_some() {
+                InitEngine::Godot
+            } else if engine.html5.is_some() {
+                InitEngine::HTML5
+            } else {
+                InitEngine::Custom
+            }
+        } else if self.unity {
 			InitEngine::Unity
 		} else if self.unreal {
 			InitEngine::Unreal

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -123,51 +123,52 @@ impl Opts {
 			.init_ctx_and_token(term, token.as_ref().map(|x| x.as_str()), api_endpoint)
 			.await?;
 
-        // Attempt to read the existing config
-        let partial_config = 
-			commands::version::read_config_partial(Vec::new(), None).await.ok();
+		// Attempt to read the existing config
+		let partial_config = commands::version::read_config_partial(Vec::new(), None)
+			.await
+			.ok();
 
 		// Select the engine to use
-        let init_engine = if let Some(partial_config)  = &partial_config{
-            // Read the engine from the existing config
+		let init_engine = if let Some(partial_config) = &partial_config {
+			// Read the engine from the existing config
 
-            if let Some(engine) = &partial_config.engine {
-                if engine.unity.is_some() {
-                    InitEngine::Unity
-                } else if engine.unreal.is_some() {
-                    InitEngine::Unreal
-                } else if engine.godot.is_some() {
-                    InitEngine::Godot
-                } else if engine.html5.is_some() {
-                    InitEngine::HTML5
-                } else {
-                    InitEngine::Custom
-                }
-            } else {
-                InitEngine::Custom
-            }
-        } else {
-            // Use user input for the engine
+			if let Some(engine) = &partial_config.engine {
+				if engine.unity.is_some() {
+					InitEngine::Unity
+				} else if engine.unreal.is_some() {
+					InitEngine::Unreal
+				} else if engine.godot.is_some() {
+					InitEngine::Godot
+				} else if engine.html5.is_some() {
+					InitEngine::HTML5
+				} else {
+					InitEngine::Custom
+				}
+			} else {
+				InitEngine::Custom
+			}
+		} else {
+			// Use user input for the engine
 
-            if self.unity {
-                InitEngine::Unity
-            } else if self.unreal {
-                InitEngine::Unreal
-            } else if self.godot {
-                InitEngine::Godot
-            } else if self.html5 {
-                InitEngine::HTML5
-            } else if self.custom {
-                InitEngine::Custom
-            } else {
-                let engine = term::Prompt::new("What engine are you using?")
-                    .docs("unity, unreal, godot, html5, or custom")
-                    .default_value("custom")
-                    .parsed::<InitEngine>(term)
-                    .await?;
-                engine
-            }
-        };
+			if self.unity {
+				InitEngine::Unity
+			} else if self.unreal {
+				InitEngine::Unreal
+			} else if self.godot {
+				InitEngine::Godot
+			} else if self.html5 {
+				InitEngine::HTML5
+			} else if self.custom {
+				InitEngine::Custom
+			} else {
+				let engine = term::Prompt::new("What engine are you using?")
+					.docs("unity, unreal, godot, html5, or custom")
+					.default_value("custom")
+					.parsed::<InitEngine>(term)
+					.await?;
+				engine
+			}
+		};
 
 		// Run setup process
 		match init_engine {

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -128,36 +128,46 @@ impl Opts {
 			commands::version::read_config_partial(Vec::new(), None).await.ok();
 
 		// Select the engine to use
-		let init_engine = if let Some(engine) = partial_config.as_ref().and_then(|x| x.engine.as_ref()) {
-            if engine.unity.is_some() {
-                InitEngine::Unity
-            } else if engine.unreal.is_some() {
-                InitEngine::Unreal
-            } else if engine.godot.is_some() {
-                InitEngine::Godot
-            } else if engine.html5.is_some() {
-                InitEngine::HTML5
+        let init_engine = if let Some(partial_config)  = &partial_config{
+            // Read the engine from the existing config
+
+            if let Some(engine) = &partial_config.engine {
+                if engine.unity.is_some() {
+                    InitEngine::Unity
+                } else if engine.unreal.is_some() {
+                    InitEngine::Unreal
+                } else if engine.godot.is_some() {
+                    InitEngine::Godot
+                } else if engine.html5.is_some() {
+                    InitEngine::HTML5
+                } else {
+                    InitEngine::Custom
+                }
             } else {
                 InitEngine::Custom
             }
-        } else if self.unity {
-			InitEngine::Unity
-		} else if self.unreal {
-			InitEngine::Unreal
-		} else if self.godot {
-			InitEngine::Godot
-		} else if self.html5 {
-			InitEngine::HTML5
-		} else if self.custom {
-			InitEngine::Custom
-		} else {
-			let engine = term::Prompt::new("What engine are you using?")
-				.docs("unity, unreal, godot, html5, or custom")
-				.default_value("custom")
-				.parsed::<InitEngine>(term)
-				.await?;
-			engine
-		};
+        } else {
+            // Use user input for the engine
+
+            if self.unity {
+                InitEngine::Unity
+            } else if self.unreal {
+                InitEngine::Unreal
+            } else if self.godot {
+                InitEngine::Godot
+            } else if self.html5 {
+                InitEngine::HTML5
+            } else if self.custom {
+                InitEngine::Custom
+            } else {
+                let engine = term::Prompt::new("What engine are you using?")
+                    .docs("unity, unreal, godot, html5, or custom")
+                    .default_value("custom")
+                    .parsed::<InitEngine>(term)
+                    .await?;
+                engine
+            }
+        };
 
 		// Run setup process
 		match init_engine {


### PR DESCRIPTION
Remove redundant prompt for init engine

Don't prompt for engine if config already exists

changelog

compile error