### PR TITLE
Update rivet.toml links to serverless-lobbies path to use the new /dynamic-servers path.

### DIFF
--- a/cli/tpl/default_config/matchmaker.yaml
+++ b/cli/tpl/default_config/matchmaker.yaml
@@ -9,7 +9,7 @@ matchmaker:
 
   # The hardware to provide for lobbies.
   #
-  # Available tiers: https://rivet.gg/docs/serverless-lobbies/concepts/available-tiers
+  # Available tiers: https://rivet.gg/docs/dynamic-servers/concepts/available-tiers
   tier: basic-1d1
 
   # What game modes are available.
@@ -28,7 +28,7 @@ matchmaker:
     # Which ports to allow players to connect to. Multiple ports can be defined
     # with different protocols.
     #
-    # How ports work: https://rivet.gg/docs/serverless-lobbies/concepts/ports
+    # How ports work: https://rivet.gg/docs/dynamic-servers/concepts/ports
     ports:
       default:
         port: __PORT__

--- a/cli/tpl/unreal_config/config.yaml
+++ b/cli/tpl/unreal_config/config.yaml
@@ -20,7 +20,7 @@ matchmaker:
 
   # The hardware to provide for lobbies.
   #
-  # Available tiers: https://rivet.gg/docs/serverless-lobbies/concepts/available-tiers
+  # Available tiers: https://rivet.gg/docs/dynamic-servers/concepts/available-tiers
   tier: basic-1d1
 
   # What game modes are available.


### PR DESCRIPTION
I'm doing an integration and found this broken links.