### PR TITLE
Added get version url command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1691,6 +1691,7 @@ dependencies = [
  "term_size",
  "tokio",
  "tokio-util",
+ "url",
  "uuid",
  "vergen",
  "webbrowser",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -39,6 +39,7 @@ tempfile = "3.2"
 term_size = "0.3.2"
 tokio = { version = "1.27", default-features = false, features = ["fs", "macros", "process", "rt"] }
 tokio-util = { version = "0.7", default-features = false, features = ["io-util"] }
+url = "2.5.0"
 uuid = { version = "1.3", features = ["v4"] }
 webbrowser = "0.8.7"
 zip = "0.5"


### PR DESCRIPTION
This will close GDT-40

---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request adds a new feature to the CLI tool that allows users to get the version of a game in a specific namespace. It also includes the addition of the `url` dependency to the project.
> 
> ## What changed
> - Added `url` dependency to `Cargo.toml` and `Cargo.lock`.
> - Added a new `GetVersion` subcommand to `sidekick.rs` which takes a namespace as an argument.
> - The `GetVersion` subcommand makes an API call to get the game ID, constructs a URL using the game ID and namespace, and then modifies the subdomain of the URL from `api` to `hub`.
> - The modified URL is then returned as a JSON response.
> 
> ## How to test
> 1. Pull the changes from this PR and build the project.
> 2. Run the CLI tool with the new `GetVersion` subcommand and a namespace argument.
> 3. Verify that the output is a URL with the `hub` subdomain and the correct game ID and namespace in the path.
> 
> ## Why make this change
> This change allows users to easily get the version of a game in a specific namespace using the CLI tool. This can be useful for debugging, testing, and automation tasks. The addition of the `url` dependency allows for easy and safe URL manipulation.
</details>