### PR TITLE
Fix game mode Docker configs not reading default image ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix `matchmaker.game_modes.*.docker.image_id` from `matchmaker.docker.image_id`
 - **Install script** Now installs non-prerelease GitHub releases
 
 ## [v0.3.0] - 2023-12-10


### PR DESCRIPTION
This config causes `matchmaker.game_modes.test.image_id` to not be set to the value of `matchmaker.docker.image_id`.


```yaml
matchmaker:
  docker:
    dockerfile: Dockerfile.test
  game_modes:
    test:
      docker:
        env:
          FOO: bar
```

