### PR TITLE
Open terminal flag

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -43,6 +43,7 @@ tokio-util = { version = "0.7", default-features = false, features = ["io-util"]
 url = "2.5.0"
 uuid = { version = "1.3", features = ["v4"] }
 webbrowser = "0.8.7"
+which = "5.0.0"
 zip = "0.5"
 
 [target.'cfg(unix)'.dependencies]

--- a/cli/src/commands/sidekick/mod.rs
+++ b/cli/src/commands/sidekick/mod.rs
@@ -1,9 +1,9 @@
 use clap::Parser;
-
 use console::Term;
 use global_error::prelude::*;
 use serde::Serialize;
 use serde_json::{json, Value};
+use std::process::Command;
 
 use crate::util::{
 	global_config,
@@ -47,19 +47,78 @@ fn serialize_output(v: GlobalResult<impl Serialize>) -> GlobalResult<Value> {
 	Ok(unwrap!(serde_json::to_value(&unwrap!(v))))
 }
 
-fn serialize_output(v: GlobalResult<impl Serialize>) -> GlobalResult<String> {
-	Ok(format!(
-		"{}",
-		unwrap!(
-			serde_json::to_string(&unwrap!(v)),
-			"couldn't serialize output"
-		)
-	))
-
 pub enum PreExecuteHandled {
 	Yes,
 	No,
 }
+
+struct Terminal {
+	/// The name of the terminal emulator command
+	name: &'static str,
+	/// The flag to pass the command to the terminal emulator
+	prompt_str: &'static str,
+	/// Whether the command should be passed as a single argument (quoted) or as
+	/// multiple arguments
+	quote: bool,
+}
+
+/// Terminals that don't work (note, more work might make them work):
+///
+/// - guake (runs the whole window, doesn't handle closing)
+/// - upterm (doesn't have an arg to pass a command it)
+/// - x-terminal-emulator
+const TERMINALS: [Terminal; 10] = [
+	Terminal {
+		name: "gnome-terminal",
+		prompt_str: "--",
+		quote: false,
+	},
+	Terminal {
+		name: "kitty",
+		prompt_str: "-e",
+		quote: false,
+	},
+	Terminal {
+		name: "konsole",
+		prompt_str: "-e",
+		quote: false,
+	},
+	Terminal {
+		name: "st",
+		prompt_str: "-e",
+		quote: false,
+	},
+	Terminal {
+		name: "terminator",
+		prompt_str: "-e",
+		quote: true,
+	},
+	Terminal {
+		name: "tilda",
+		prompt_str: "-c",
+		quote: true,
+	},
+	Terminal {
+		name: "tilix",
+		prompt_str: "-e",
+		quote: false,
+	},
+	Terminal {
+		name: "urxvt",
+		prompt_str: "-e",
+		quote: false,
+	},
+	Terminal {
+		name: "xfce4-terminal",
+		prompt_str: "-e",
+		quote: true,
+	},
+	Terminal {
+		name: "xterm",
+		prompt_str: "-e",
+		quote: false,
+	},
+];
 
 impl SubCommand {
 	/// These commands run before a token is required, so they don't have access
@@ -96,7 +155,17 @@ impl SubCommand {
 		Ok(handled)
 	}
 
-	pub async fn execute(&self, ctx: &cli_core::Ctx, _term: &Term) -> GlobalResult<()> {
+	pub async fn execute(
+		&self,
+		ctx: &cli_core::Ctx,
+		_term: &Term,
+		show_terminal: bool,
+	) -> GlobalResult<()> {
+		if show_terminal {
+			SubCommand::show_terminal(ctx).await?;
+			return Ok(());
+		}
+
 		let (_api_endpoint, _token) = global_config::read_project(|x| {
 			(x.cluster.api_endpoint.clone(), x.tokens.cloud.clone())
 		})
@@ -144,5 +213,142 @@ impl SubCommand {
 		}
 
 		Ok(())
+	}
+
+	pub async fn show_terminal(ctx: &cli_core::Ctx) -> GlobalResult<()> {
+		// TODO(forest): The code doesn't handle the case where the binary
+		// path or the arguments contain special characters that might need
+		// to be escaped or quoted.
+		let binary_path = std::env::current_exe()?;
+
+		// TODO(forest): The command is constructed by joining the arguments
+		// with spaces. This might not work correctly if any of the
+		// arguments contain spaces themselves. You might need to escape or
+		// quote these arguments.
+		let args = std::env::args().collect::<Vec<_>>();
+
+		// We can get rid of the first since it's the relative path to the
+		// binary. Then, we need to remove any argument that starts with
+		// `--show-shell`
+		let mut args = args
+			.into_iter()
+			.skip(1)
+			.filter(|x| !x.starts_with("--show-terminal"))
+			.collect::<Vec<_>>();
+
+		// Add the binary path back as the first argument
+		args.insert(0, binary_path.to_str().unwrap().to_string());
+
+		let command_to_run = format!("{} {}", binary_path.to_str().unwrap(), args.join(" "));
+
+		#[cfg(target_os = "windows")]
+		Command::new("cmd.exe")
+			.arg("/C")
+			.args(args)
+			.spawn()
+			.expect("cmd.exe failed to start");
+
+		#[cfg(target_os = "macos")]
+		{
+			let command_to_run = args.join(" ");
+			let apple_script = format!(
+				"tell application \"Terminal\"
+						activate
+						do script \"{}\"
+					end tell",
+				command_to_run
+			);
+
+			Command::new("osascript")
+				.arg("-e")
+				.arg(apple_script)
+				.spawn()
+				.expect("Terminal failed to start");
+		}
+
+		#[cfg(target_os = "linux")]
+		{
+			// TODO(forest): For Linux, the code is trying to find an
+			// available terminal emulator from a predefined list and
+			// then run the command in it. However, the way to run a
+			// command in a terminal emulator can vary between different
+			// emulators. The -e flag used here might not work for all
+			// of them.
+			let mut command = None;
+
+			for terminal in &TERMINALS {
+				if which::which(terminal.name).is_ok() {
+					command = Some(terminal);
+					break;
+				}
+			}
+
+			match command {
+				Some(terminal) => {
+					if terminal.quote {
+						args = vec![args.join(" ")];
+					}
+
+					Command::new(terminal.name)
+						// This is the flag to run a command in the
+						// terminal. Most will use -e, but some might use
+						// something different.
+						.arg(terminal.prompt_str)
+						.args(args)
+						.spawn()
+						.expect("Terminal emulator failed to start");
+				}
+				None => {
+					panic!("No terminal emulator found");
+				}
+			}
+		}
+
+		Ok(())
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use std::fs;
+	use std::path::Path;
+	use std::process::Command;
+
+	use super::TERMINALS;
+
+	#[test]
+	#[ignore]
+	/// This test makes sure that the configuration to run a command in each
+	/// terminal works. It shouldn't run in CI, since it would be difficult to
+	/// configure. It can be run locally if each terminal in the const is
+	/// installed.
+	fn test_terminals() {
+		for terminal in TERMINALS {
+			let file_name = format!("{}.txt", terminal.name);
+
+			let mut args = Vec::new();
+			// If we want to pass the command as a single string, we can just do
+			// an entire string
+			if terminal.quote {
+				args.push(format!("touch {}", file_name));
+			} else {
+				args.push("touch".to_string());
+				args.push(file_name.clone());
+			}
+
+			let output = Command::new(terminal.name)
+				.arg(terminal.prompt_str)
+				.args(&args)
+				.output()
+				.expect("Failed to execute command");
+
+			assert!(output.status.success(), "Command failed: {}", terminal.name);
+
+			let file_path = Path::new(&file_name);
+			assert!(file_path.exists(), "File does not exist: {}", file_name);
+
+			// Clean up the file
+			fs::remove_file(file_path).expect("Failed to remove file");
+		}
 	}
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -105,6 +105,9 @@ enum SubCommand {
 	Sidekick {
 		#[clap(subcommand)]
 		command: sidekick::SubCommand,
+		// #[clap(opts)]
+		#[clap(long)]
+		show_terminal: bool,
 	},
 
 	/// Alias of `rivet engine unreal`
@@ -177,7 +180,7 @@ async fn main_inner(opts: Opts) -> GlobalResult<()> {
 			.await?;
 
 	// Sidekick sign-in can also be called before the token is valitdated
-	if let SubCommand::Sidekick { command } = &opts.command {
+	if let SubCommand::Sidekick { command, show_terminal } = &opts.command {
 		if let Ok(PreExecuteHandled::Yes) = command.pre_execute(&token).await {
 			return Ok(());
 		}
@@ -220,7 +223,10 @@ async fn main_inner(opts: Opts) -> GlobalResult<()> {
 		SubCommand::Engine { command } => command.execute(&ctx).await?,
 		SubCommand::Unreal { command } => command.execute(&ctx).await?,
 		SubCommand::CI { command } => command.execute(&ctx).await?,
-		SubCommand::Sidekick { command } => command.execute(&ctx, &term).await?,
+		SubCommand::Sidekick {
+			command,
+			show_terminal,
+		} => command.execute(&ctx, &term, show_terminal).await?,
 	}
 
 	Ok(())


### PR DESCRIPTION
This will close GDT-32, GDT-13

---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> # TL;DR
> This pull request adds the `which` crate as a dependency and modifies the `execute` function in the `sidekick.rs` file to include a new parameter `show_terminal` which determines whether to open a new terminal window and call the command again within it.
> 
> # What changed
> - Added the `which` crate as a dependency in the `Cargo.lock` and `Cargo.toml` files.
> - Modified the `execute` function in the `sidekick.rs` file to include a new parameter `show_terminal`.
> - Added logic to open a new terminal window and call the command again within it if `show_terminal` is true.
> 
> # How to test
> 1. Run the application with the `show_terminal` flag set to true.
> 2. Verify that a new terminal window is opened and the command is executed within it.
> 
> # Why make this change
> This change was made to provide the option to open a new terminal window and execute the command within it. This can be useful in certain scenarios where the command needs to be run in a separate terminal environment. The addition of the `which` crate as a dependency allows for the detection of available terminal emulators on Linux systems.
</details>