### PR TITLE
Build and deploy

### DIFF
--- a/cli/src/commands/sidekick/deploy.rs
+++ b/cli/src/commands/sidekick/deploy.rs
@@ -1,0 +1,70 @@
+use clap::Parser;
+use cli_core::{ctx, rivet_api::apis};
+use global_error::prelude::*;
+use serde::Serialize;
+
+use crate::commands::config::parse_config_override_args;
+use crate::commands::deploy::build_and_push_compat;
+use crate::commands::deploy::deploy;
+use crate::util::global_config;
+use crate::util::struct_fmt;
+
+use super::SideKickHandler;
+
+#[derive(Parser)]
+pub struct Opts {
+	/// Name of the version to create
+	#[clap(long = "name", alias = "display-name")]
+	display_name: Option<String>,
+
+	/// Override specific properties of the config
+	#[clap(long = "override", short)]
+	overrides: Vec<String>,
+
+	/// Namespace ID to deploy to
+	#[clap(short = 'n', long)]
+	namespace: Option<String>,
+
+	/// Number of files to upload in parallel
+	#[clap(long, env = "RIVET_CONCURRENT_UPLOADS", default_value = "8")]
+	concurrent_uploads: usize,
+}
+
+#[derive(Serialize)]
+pub struct Output {}
+
+impl SideKickHandler for Output {}
+
+impl Opts {
+	pub async fn execute(&self, ctx: &cli_core::Ctx) -> GlobalResult<Output> {
+		// Parse overrides
+		let mut overrides = parse_config_override_args(&self.overrides)?;
+
+		// Build & push site & build before creating version
+		build_and_push_compat(
+			ctx,
+			&mut overrides,
+			&None,
+			&None,
+			&None,
+			&None,
+			self.concurrent_uploads,
+			&None,
+		)
+		.await?;
+
+		// Create version
+		let output = deploy(
+			ctx,
+			self.display_name.as_ref().map(String::as_str),
+			overrides,
+			self.namespace.as_ref().map(String::as_str),
+			self.concurrent_uploads,
+			None,
+		)
+		.await?;
+		struct_fmt::print_opt(None, &output)?;
+
+		Ok(Output {})
+	}
+}

--- a/cli/src/commands/sidekick/mod.rs
+++ b/cli/src/commands/sidekick/mod.rs
@@ -15,6 +15,7 @@ pub mod get_link;
 pub mod get_token;
 pub mod get_version;
 pub mod wait_for_login;
+pub mod deploy;
 
 pub trait SideKickHandler: Serialize {
 	fn print(&self) {
@@ -34,6 +35,8 @@ pub enum SubCommand {
 	GetToken(get_token::Opts),
 	/// Get the version of the CLI
 	GetVersion(get_version::Opts),
+	/// Deploy a version
+	Deploy(deploy::Opts),
 }
 
 /// Any response that can come from the sidekick. There should only be a single
@@ -179,6 +182,7 @@ impl SubCommand {
 			}
 			SubCommand::GetToken(opts) => serialize_output(opts.execute(ctx).await),
 			SubCommand::GetVersion(opts) => serialize_output(opts.execute(ctx).await),
+			SubCommand::Deploy(opts) => serialize_output(opts.execute(ctx).await),
 		};
 
 		// Print the response

--- a/cli/src/commands/sidekick/wait_for_login.rs
+++ b/cli/src/commands/sidekick/wait_for_login.rs
@@ -11,7 +11,7 @@ use super::SideKickHandler;
 #[derive(Parser)]
 pub struct Opts {
 	/// The token to poll for
-	#[structopt(short, long)]
+	#[structopt(long)]
 	device_link_token: String,
 }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -180,7 +180,11 @@ async fn main_inner(opts: Opts) -> GlobalResult<()> {
 			.await?;
 
 	// Sidekick sign-in can also be called before the token is valitdated
-	if let SubCommand::Sidekick { command, show_terminal } = &opts.command {
+	if let SubCommand::Sidekick {
+		command,
+		show_terminal,
+	} = &opts.command
+	{
 		if let Ok(PreExecuteHandled::Yes) = command.pre_execute(&token).await {
 			return Ok(());
 		}


### PR DESCRIPTION
This will close CLI-37

---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request introduces a new `Deploy` subcommand to the CLI, allowing users to deploy a version of their application. It also includes several changes to existing subcommands, such as removing short options for `device_link_token` and `namespace` in `WaitForLogin` and `GetVersion` respectively.
> 
> ## What changed
> - A new `Deploy` subcommand has been added, which includes several options such as `display_name`, `overrides`, `namespace`, `build_tag`, `build_name`, `site_path`, `site_name`, and `format`.
> - The `WaitForLogin` and `GetVersion` subcommands have been modified to only accept long options for `device_link_token` and `namespace` respectively.
> - The `Deploy` subcommand includes functionality to parse config override arguments, build and push the site and build before creating a version, and create a version.
> 
> ## How to test
> 1. Pull down the changes from this branch.
> 2. Run the CLI with the new `Deploy` subcommand and various options to test the new functionality.
> 3. Test the `WaitForLogin` and `GetVersion` subcommands to ensure they still function as expected with the modified options.
> 
> ## Why make this change
> The addition of the `Deploy` subcommand enhances the functionality of the CLI by allowing users to deploy a version of their application directly from the command line. The changes to the `WaitForLogin` and `GetVersion` subcommands improve usability by simplifying the options.
</details>