### PR TITLE
Enable pipefail in CI to fix CDN/Docker step not failing successfully

### DIFF
--- a/cli/tpl/ci/github/foot.yml
+++ b/cli/tpl/ci/github/foot.yml
@@ -2,6 +2,9 @@
     name: Deploy
     needs: [prepare, __NEEDS_JOBS__]
     runs-on: ubuntu-20.04
+    defaults:
+      run:
+        shell: bash
     env:
       RIVET_API_ENDPOINT: "__RIVET_API_ENDPOINT__"
       RIVET_TOKEN: ${{ secrets.RIVET_TOKEN }}
@@ -16,8 +19,7 @@
 
       - name: Create Namespace
         run: |
-          # Ignore error if namespace already exists
-          rivet namespace create --id "${{ needs.prepare.outputs.ns_name_id }}" --name "${{ needs.prepare.outputs.branch_name }}" || true
+          rivet namespace create --id "${{ needs.prepare.outputs.ns_name_id }}" --name "${{ needs.prepare.outputs.branch_name }}"
 
       - name: Deploy Version
         run: |

--- a/cli/tpl/ci/github/head.yml
+++ b/cli/tpl/ci/github/head.yml
@@ -18,6 +18,9 @@ jobs:
       branch_name: ${{ steps.derive_names.outputs.branch_name }}
       ns_name_id: ${{ steps.derive_names.outputs.ns_name_id }}
       version_name: ${{ steps.derive_names.outputs.version_name }}
+    defaults:
+      run:
+        shell: bash
     env:
       RIVET_API_ENDPOINT: "__RIVET_API_ENDPOINT__"
       RIVET_TOKEN: ${{ secrets.RIVET_TOKEN }}

--- a/cli/tpl/ci/github/job-cdn.yml
+++ b/cli/tpl/ci/github/job-cdn.yml
@@ -4,6 +4,9 @@
     runs-on: ubuntu-20.04
     outputs:
       site_id: ${{ steps.build_cdn.outputs.site_id }}
+    defaults:
+      run:
+        shell: bash
     env:
       RIVET_API_ENDPOINT: "__RIVET_API_ENDPOINT__"
       RIVET_TOKEN: ${{ secrets.RIVET_TOKEN }}

--- a/cli/tpl/ci/github/job-image.yml
+++ b/cli/tpl/ci/github/job-image.yml
@@ -4,6 +4,9 @@
     runs-on: ubuntu-20.04
     outputs:
       image_id: ${{ steps.build_image.outputs.image_id }}
+    defaults:
+      run:
+        shell: bash
     env:
       RIVET_API_ENDPOINT: "__RIVET_API_ENDPOINT__"
       RIVET_TOKEN: ${{ secrets.RIVET_TOKEN }}


### PR DESCRIPTION
Commands like: `output=$(rivet image build-push ..etc..)` would not exit with a non-0 code since it's in a pipe. Now, all commands fail completely.

Note the `pipefail` option is enabled when the shell is set to `bash`. [Source](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell)