### PR TITLE
Fix init deleting all Rivet folder files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Overriding `matchmaker.docker.image_id` getting ignored
 - `rivet config validate` now uses `--print` flag instead of a positional argument
+- Only delete `.rivet/config.*` to keep other files in `./.rivet` directory
 
 ## [v1.0.0-rc.1] - 2023-12-24
 


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> # Pull Request Description
> 
> ## TL;DR
> This pull request modifies the deletion of legacy `.rivet` directory to only delete `config.[yaml|toml|json]` files, preserving other files in the directory.
> 
> ## What changed
> The `execute` function in `cli/src/commands/init.rs` was modified. Instead of deleting the entire `.rivet` directory, it now iterates over the files in the directory and only deletes those that start with "config".
> 
> The `CHANGELOG.md` was also updated to reflect this change under the "Fixed" section for the unreleased version `v1.0.0-rc.2`.
> 
> ## How to test
> To test this change, you can create a `.rivet` directory with a mix of `config.[yaml|toml|json]` files and other files. Run the `execute` function and verify that only the `config.[yaml|toml|json]` files are deleted, while other files remain intact.
> 
> ## Why make this change
> This change is necessary to prevent the deletion of potentially important files in the `.rivet` directory that are not related to the legacy project metadata. By only deleting the `config.[yaml|toml|json]` files, we ensure that other files are preserved.
</details>