### PR TITLE
ci: explicitly fmt check members

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,10 @@ jobs:
 
       - name: Run cargo fmt
         run: |
-          nix-shell --run "cargo fmt --all --check"
+          nix-shell --run "
+            cargo fmt --check --manifest-path core/Cargo.toml && 
+            cargo fmt --check --manifest-path cli/Cargo.toml
+          "
 
       - name: Run cargo test
         env:


### PR DESCRIPTION
`sdks/` is getting caught in the fmt check, so this will just check `cli` and `core`. The alternative, adding an ignore to `rustfmt.toml`, will only work on nightly, and that would be harder to get set up correctly.