### PR TITLE
fix: revert regression with config-rs dependency

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -20,7 +20,7 @@ clap = { version = "3.2.16", features = ["derive", "env"] }
 cli-core = { path = "../core", package = "rivet-cli-core" }
 # Disable less common file formats. Preserve TOML for backwards compatibility.
 # This is pointing to a fork that contains a fix for Byte-order marks on Windows.
-config = { git = "https://github.com/AngelOnFira/config-rs", rev = "04e61354912543e23e70b6851a3f4b03ce69471c", default-features = false, features = ["yaml", "toml", "json"] }
+config = { git = "https://github.com/rivet-gg/config-rs", rev = "0f3c89b4770276e8db72ce962974a9a72c59c97a", default-features = false, features = ["yaml", "toml", "json"] }
 console = "0.15"
 dirs = "5.0"
 fs_extra = "1.2.0"


### PR DESCRIPTION
Relevant changes https://github.com/rivet-gg/config-rs/pull/2