### PR TITLE
chore: don't prompt env selection if there's only one env

### DIFF
--- a/packages/cli/src/commands/environment/select.rs
+++ b/packages/cli/src/commands/environment/select.rs
@@ -7,7 +7,7 @@ pub struct Opts {}
 impl Opts {
 	pub async fn execute(&self) -> Result<()> {
 		let ctx = toolchain::toolchain_ctx::load().await?;
-		crate::util::env::select(&ctx).await?;
+		crate::util::env::select(&ctx, true).await?;
 		Ok(())
 	}
 }

--- a/packages/cli/src/util/env.rs
+++ b/packages/cli/src/util/env.rs
@@ -31,11 +31,13 @@ pub async fn get_or_select(
 	}
 
 	// Prompt user for selection
-	select(ctx).await
+	select(ctx, false).await
 }
 
 /// Select an environment.
-pub async fn select(ctx: &toolchain::ToolchainCtx) -> Result<String> {
+///
+/// Forcing selection will prompt the user for selection, even if there's only 1 item.
+pub async fn select(ctx: &toolchain::ToolchainCtx, force_select: bool) -> Result<String> {
 	// Build selections
 	let mut envs = ctx
 		.project
@@ -48,6 +50,12 @@ pub async fn select(ctx: &toolchain::ToolchainCtx) -> Result<String> {
 		})
 		.collect::<Vec<_>>();
 	envs.sort_by_key(|e| e.name.clone());
+
+	// If only one env, don't prompt
+	if !force_select && envs.len() == 1 {
+		let env = envs.into_iter().next().expect("should have 1 env value");
+		return Ok(env.slug);
+	}
 
 	// Choose starting index
 	let start_env_id =


### PR DESCRIPTION
Fixes RVT-4232
